### PR TITLE
Improve mobile nav and add cart page

### DIFF
--- a/cart.html
+++ b/cart.html
@@ -1,0 +1,109 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Cart</title>
+    <link rel="stylesheet" href="style.css">
+    <script src="https://cdn.tailwindcss.com"></script>
+</head>
+<body>
+    <nav class="bg-gradient-to-r from-blue-600 via-purple-600 to-pink-600 p-4 shadow-lg">
+        <div class="container mx-auto flex justify-between items-center text-white">
+            <div class="flex items-center">
+                <span class="text-xl font-bold">Neebys</span>
+                <button id="menu-btn" class="sm:hidden ml-4 px-2 py-1 bg-white text-gray-800 rounded">☰</button>
+            </div>
+            <ul id="nav-links" class="hidden sm:flex space-x-4">
+                <li><a class="hover:underline" href="index.html">Home</a></li>
+                <li><a class="hover:underline" href="about.html">About</a></li>
+                <li><a class="hover:underline" href="contact.html">Contact</a></li>
+            </ul>
+            <div class="space-x-4 flex items-center">
+                <a href="profile.html" class="hidden sm:inline px-3 py-1 bg-white text-gray-800 rounded shadow transition hover:shadow-lg active:scale-95">Profile</a>
+                <button id="logout-btn" class="hidden sm:inline px-3 py-1 bg-white text-gray-800 rounded shadow transition hover:shadow-lg active:scale-95">Log Out</button>
+                <a href="cart.html" class="relative inline-block">
+                    <span class="text-2xl">🛒</span>
+                    <span id="cart-count" class="absolute -top-2 -right-2 bg-red-600 text-white text-xs rounded-full px-1">0</span>
+                </a>
+            </div>
+        </div>
+    </nav>
+    <div id="sidebar" class="fixed inset-y-0 left-0 w-64 bg-white transform -translate-x-full transition-transform duration-200 sm:hidden z-50 shadow-lg">
+        <button id="close-sidebar" class="m-4 text-gray-600">Close</button>
+        <ul class="mt-8 space-y-4 px-4">
+            <li><a class="block hover:underline" href="index.html">Home</a></li>
+            <li><a class="block hover:underline" href="about.html">About</a></li>
+            <li><a class="block hover:underline" href="contact.html">Contact</a></li>
+            <li><a class="block hover:underline" href="profile.html">Profile</a></li>
+            <li><button id="sidebar-logout" class="w-full text-left hover:underline">Log Out</button></li>
+        </ul>
+    </div>
+    <div id="overlay" class="fixed inset-0 bg-black bg-opacity-50 hidden sm:hidden z-40"></div>
+    <main class="container mx-auto py-8">
+        <h1 class="text-2xl font-bold mb-4">Your Cart</h1>
+        <div id="cart-items" class="space-y-4"></div>
+        <p id="empty-msg" class="text-gray-500">Your cart is empty.</p>
+        <div id="checkout-section" class="mt-4 hidden">
+            <button class="bg-green-600 text-white px-4 py-2 rounded">Checkout</button>
+        </div>
+    </main>
+    <footer class="bg-gray-800 text-white text-center py-4 fixed bottom-0 w-full">
+        <p>&copy; 2025 Basic Website</p>
+    </footer>
+    <script>
+        const cartCountEl = document.getElementById('cart-count');
+        let cart = JSON.parse(localStorage.getItem('cart') || '{}');
+
+        function updateCartCount() {
+            const total = Object.values(cart).reduce((a, b) => a + b, 0);
+            cartCountEl.textContent = total;
+        }
+
+        function renderCart() {
+            const container = document.getElementById('cart-items');
+            container.innerHTML = '';
+            const keys = Object.keys(cart);
+            if (keys.length === 0) {
+                document.getElementById('empty-msg').classList.remove('hidden');
+                document.getElementById('checkout-section').classList.add('hidden');
+                return;
+            }
+            document.getElementById('empty-msg').classList.add('hidden');
+            document.getElementById('checkout-section').classList.remove('hidden');
+            keys.forEach(name => {
+                const qty = cart[name];
+                const div = document.createElement('div');
+                div.className = 'flex justify-between border p-2 rounded';
+                div.textContent = `${name} x ${qty}`;
+                container.appendChild(div);
+            });
+        }
+
+        document.getElementById('menu-btn').addEventListener('click', () => {
+            document.getElementById('sidebar').classList.remove('-translate-x-full');
+            document.getElementById('overlay').classList.remove('hidden');
+        });
+        document.getElementById('close-sidebar').addEventListener('click', () => {
+            document.getElementById('sidebar').classList.add('-translate-x-full');
+            document.getElementById('overlay').classList.add('hidden');
+        });
+        document.getElementById('overlay').addEventListener('click', () => {
+            document.getElementById('sidebar').classList.add('-translate-x-full');
+            document.getElementById('overlay').classList.add('hidden');
+        });
+        document.getElementById('sidebar-logout').addEventListener('click', () => {
+            document.getElementById('logout-btn').click();
+        });
+
+        document.getElementById('logout-btn').addEventListener('click', () => {
+            if (confirm('Are you sure you want to logout?')) {
+                alert('Logged out');
+            }
+        });
+
+        updateCartCount();
+        renderCart();
+    </script>
+</body>
+</html>

--- a/index.html
+++ b/index.html
@@ -11,123 +11,128 @@
 <body>
     <nav class="bg-gradient-to-r from-blue-600 via-purple-600 to-pink-600 p-4 shadow-lg">
         <div class="container mx-auto flex justify-between items-center text-white">
-            <ul class="flex space-x-4">
+            <div class="flex items-center">
+                <span class="text-xl font-bold">Neebys</span>
+                <button id="menu-btn" class="sm:hidden ml-4 px-2 py-1 bg-white text-gray-800 rounded">☰</button>
+            </div>
+            <ul id="nav-links" class="hidden sm:flex space-x-4">
                 <li><a class="hover:underline" href="index.html">Home</a></li>
                 <li><a class="hover:underline" href="about.html">About</a></li>
                 <li><a class="hover:underline" href="contact.html">Contact</a></li>
             </ul>
             <div class="space-x-4 flex items-center">
-                <a href="profile.html" class="px-3 py-1 bg-white text-gray-800 rounded shadow transition hover:shadow-lg active:scale-95">Profile</a>
-                <button id="logout-btn" class="px-3 py-1 bg-white text-gray-800 rounded shadow transition hover:shadow-lg active:scale-95">Log Out</button>
-                <div class="relative inline-block">
+                <a href="profile.html" class="hidden sm:inline px-3 py-1 bg-white text-gray-800 rounded shadow transition hover:shadow-lg active:scale-95">Profile</a>
+                <button id="logout-btn" class="hidden sm:inline px-3 py-1 bg-white text-gray-800 rounded shadow transition hover:shadow-lg active:scale-95">Log Out</button>
+                <a href="cart.html" class="relative inline-block">
                     <span class="text-2xl">🛒</span>
                     <span id="cart-count" class="absolute -top-2 -right-2 bg-red-600 text-white text-xs rounded-full px-1">0</span>
-                </div>
+                </a>
             </div>
         </div>
     </nav>
+    <div id="sidebar" class="fixed inset-y-0 left-0 w-64 bg-white transform -translate-x-full transition-transform duration-200 sm:hidden z-50 shadow-lg">
+        <button id="close-sidebar" class="m-4 text-gray-600">Close</button>
+        <ul class="mt-8 space-y-4 px-4">
+            <li><a class="block hover:underline" href="index.html">Home</a></li>
+            <li><a class="block hover:underline" href="about.html">About</a></li>
+            <li><a class="block hover:underline" href="contact.html">Contact</a></li>
+            <li><a class="block hover:underline" href="profile.html">Profile</a></li>
+            <li><button id="sidebar-logout" class="w-full text-left hover:underline">Log Out</button></li>
+        </ul>
+    </div>
+    <div id="overlay" class="fixed inset-0 bg-black bg-opacity-50 hidden sm:hidden z-40"></div>
     <main class="container mx-auto py-8">
-        <div class="grid grid-cols-3 sm:grid-cols-3 md:grid-cols-5 gap-4" id="products">
+        <div class="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 gap-4" id="products">
             <!-- Product cards inserted by HTML -->
-            <div class="product-card bg-white rounded-lg shadow p-4 flex flex-col items-center">
-                <img class="w-full h-32 object-cover mb-2" src="https://via.placeholder.com/150" alt="Product 1">
-                <h3 class="font-semibold">Product 1</h3>
-                <div class="flex items-center mt-2 space-x-2">
-                    <button class="dec-btn px-2 bg-gray-300 rounded">-</button>
-                    <span class="qty">0</span>
-                    <button class="inc-btn px-2 bg-gray-300 rounded">+</button>
+            <div class="product-card bg-white rounded-lg shadow p-4 flex flex-col items-center text-center" data-name="Product 1">
+                <img class="w-24 h-24 object-cover mb-2 rounded" src="https://via.placeholder.com/150" alt="Product 1">
+                <h3 class="font-semibold mb-2">Product 1</h3>
+                <div class="flex items-center space-x-2 mb-2">
+                    <button class="dec-btn px-2 bg-gray-200 rounded">-</button>
+                    <button class="inc-btn px-2 bg-gray-200 rounded">+</button>
                 </div>
-                <button class="add-btn mt-2 px-3 py-1 bg-blue-600 text-white rounded">Add to Cart</button>
+                <button class="add-btn w-full px-3 py-1 bg-blue-600 text-white rounded" data-qty="0">Add</button>
             </div>
-            <div class="product-card bg-white rounded-lg shadow p-4 flex flex-col items-center">
-                <img class="w-full h-32 object-cover mb-2" src="https://via.placeholder.com/150" alt="Product 2">
-                <h3 class="font-semibold">Product 2</h3>
-                <div class="flex items-center mt-2 space-x-2">
-                    <button class="dec-btn px-2 bg-gray-300 rounded">-</button>
-                    <span class="qty">0</span>
-                    <button class="inc-btn px-2 bg-gray-300 rounded">+</button>
+            <div class="product-card bg-white rounded-lg shadow p-4 flex flex-col items-center text-center" data-name="Product 2">
+                <img class="w-24 h-24 object-cover mb-2 rounded" src="https://via.placeholder.com/150" alt="Product 2">
+                <h3 class="font-semibold mb-2">Product 2</h3>
+                <div class="flex items-center space-x-2 mb-2">
+                    <button class="dec-btn px-2 bg-gray-200 rounded">-</button>
+                    <button class="inc-btn px-2 bg-gray-200 rounded">+</button>
                 </div>
-                <button class="add-btn mt-2 px-3 py-1 bg-blue-600 text-white rounded">Add to Cart</button>
+                <button class="add-btn w-full px-3 py-1 bg-blue-600 text-white rounded" data-qty="0">Add</button>
             </div>
-            <div class="product-card bg-white rounded-lg shadow p-4 flex flex-col items-center">
-                <img class="w-full h-32 object-cover mb-2" src="https://via.placeholder.com/150" alt="Product 3">
-                <h3 class="font-semibold">Product 3</h3>
-                <div class="flex items-center mt-2 space-x-2">
-                    <button class="dec-btn px-2 bg-gray-300 rounded">-</button>
-                    <span class="qty">0</span>
-                    <button class="inc-btn px-2 bg-gray-300 rounded">+</button>
+            <div class="product-card bg-white rounded-lg shadow p-4 flex flex-col items-center text-center" data-name="Product 3">
+                <img class="w-24 h-24 object-cover mb-2 rounded" src="https://via.placeholder.com/150" alt="Product 3">
+                <h3 class="font-semibold mb-2">Product 3</h3>
+                <div class="flex items-center space-x-2 mb-2">
+                    <button class="dec-btn px-2 bg-gray-200 rounded">-</button>
+                    <button class="inc-btn px-2 bg-gray-200 rounded">+</button>
                 </div>
-                <button class="add-btn mt-2 px-3 py-1 bg-blue-600 text-white rounded">Add to Cart</button>
+                <button class="add-btn w-full px-3 py-1 bg-blue-600 text-white rounded" data-qty="0">Add</button>
             </div>
-            <div class="product-card bg-white rounded-lg shadow p-4 flex flex-col items-center">
-                <img class="w-full h-32 object-cover mb-2" src="https://via.placeholder.com/150" alt="Product 4">
-                <h3 class="font-semibold">Product 4</h3>
-                <div class="flex items-center mt-2 space-x-2">
-                    <button class="dec-btn px-2 bg-gray-300 rounded">-</button>
-                    <span class="qty">0</span>
-                    <button class="inc-btn px-2 bg-gray-300 rounded">+</button>
+            <div class="product-card bg-white rounded-lg shadow p-4 flex flex-col items-center text-center" data-name="Product 4">
+                <img class="w-24 h-24 object-cover mb-2 rounded" src="https://via.placeholder.com/150" alt="Product 4">
+                <h3 class="font-semibold mb-2">Product 4</h3>
+                <div class="flex items-center space-x-2 mb-2">
+                    <button class="dec-btn px-2 bg-gray-200 rounded">-</button>
+                    <button class="inc-btn px-2 bg-gray-200 rounded">+</button>
                 </div>
-                <button class="add-btn mt-2 px-3 py-1 bg-blue-600 text-white rounded">Add to Cart</button>
+                <button class="add-btn w-full px-3 py-1 bg-blue-600 text-white rounded" data-qty="0">Add</button>
             </div>
-            <div class="product-card bg-white rounded-lg shadow p-4 flex flex-col items-center">
-                <img class="w-full h-32 object-cover mb-2" src="https://via.placeholder.com/150" alt="Product 5">
-                <h3 class="font-semibold">Product 5</h3>
-                <div class="flex items-center mt-2 space-x-2">
-                    <button class="dec-btn px-2 bg-gray-300 rounded">-</button>
-                    <span class="qty">0</span>
-                    <button class="inc-btn px-2 bg-gray-300 rounded">+</button>
+            <div class="product-card bg-white rounded-lg shadow p-4 flex flex-col items-center text-center" data-name="Product 5">
+                <img class="w-24 h-24 object-cover mb-2 rounded" src="https://via.placeholder.com/150" alt="Product 5">
+                <h3 class="font-semibold mb-2">Product 5</h3>
+                <div class="flex items-center space-x-2 mb-2">
+                    <button class="dec-btn px-2 bg-gray-200 rounded">-</button>
+                    <button class="inc-btn px-2 bg-gray-200 rounded">+</button>
                 </div>
-                <button class="add-btn mt-2 px-3 py-1 bg-blue-600 text-white rounded">Add to Cart</button>
+                <button class="add-btn w-full px-3 py-1 bg-blue-600 text-white rounded" data-qty="0">Add</button>
             </div>
-            <div class="product-card bg-white rounded-lg shadow p-4 flex flex-col items-center">
-                <img class="w-full h-32 object-cover mb-2" src="https://via.placeholder.com/150" alt="Product 6">
-                <h3 class="font-semibold">Product 6</h3>
-                <div class="flex items-center mt-2 space-x-2">
-                    <button class="dec-btn px-2 bg-gray-300 rounded">-</button>
-                    <span class="qty">0</span>
-                    <button class="inc-btn px-2 bg-gray-300 rounded">+</button>
+            <div class="product-card bg-white rounded-lg shadow p-4 flex flex-col items-center text-center" data-name="Product 6">
+                <img class="w-24 h-24 object-cover mb-2 rounded" src="https://via.placeholder.com/150" alt="Product 6">
+                <h3 class="font-semibold mb-2">Product 6</h3>
+                <div class="flex items-center space-x-2 mb-2">
+                    <button class="dec-btn px-2 bg-gray-200 rounded">-</button>
+                    <button class="inc-btn px-2 bg-gray-200 rounded">+</button>
                 </div>
-                <button class="add-btn mt-2 px-3 py-1 bg-blue-600 text-white rounded">Add to Cart</button>
+                <button class="add-btn w-full px-3 py-1 bg-blue-600 text-white rounded" data-qty="0">Add</button>
             </div>
-            <div class="product-card bg-white rounded-lg shadow p-4 flex flex-col items-center">
-                <img class="w-full h-32 object-cover mb-2" src="https://via.placeholder.com/150" alt="Product 7">
-                <h3 class="font-semibold">Product 7</h3>
-                <div class="flex items-center mt-2 space-x-2">
-                    <button class="dec-btn px-2 bg-gray-300 rounded">-</button>
-                    <span class="qty">0</span>
-                    <button class="inc-btn px-2 bg-gray-300 rounded">+</button>
+            <div class="product-card bg-white rounded-lg shadow p-4 flex flex-col items-center text-center" data-name="Product 7">
+                <img class="w-24 h-24 object-cover mb-2 rounded" src="https://via.placeholder.com/150" alt="Product 7">
+                <h3 class="font-semibold mb-2">Product 7</h3>
+                <div class="flex items-center space-x-2 mb-2">
+                    <button class="dec-btn px-2 bg-gray-200 rounded">-</button>
+                    <button class="inc-btn px-2 bg-gray-200 rounded">+</button>
                 </div>
-                <button class="add-btn mt-2 px-3 py-1 bg-blue-600 text-white rounded">Add to Cart</button>
+                <button class="add-btn w-full px-3 py-1 bg-blue-600 text-white rounded" data-qty="0">Add</button>
             </div>
-            <div class="product-card bg-white rounded-lg shadow p-4 flex flex-col items-center">
-                <img class="w-full h-32 object-cover mb-2" src="https://via.placeholder.com/150" alt="Product 8">
-                <h3 class="font-semibold">Product 8</h3>
-                <div class="flex items-center mt-2 space-x-2">
-                    <button class="dec-btn px-2 bg-gray-300 rounded">-</button>
-                    <span class="qty">0</span>
-                    <button class="inc-btn px-2 bg-gray-300 rounded">+</button>
+            <div class="product-card bg-white rounded-lg shadow p-4 flex flex-col items-center text-center" data-name="Product 8">
+                <img class="w-24 h-24 object-cover mb-2 rounded" src="https://via.placeholder.com/150" alt="Product 8">
+                <h3 class="font-semibold mb-2">Product 8</h3>
+                <div class="flex items-center space-x-2 mb-2">
+                    <button class="dec-btn px-2 bg-gray-200 rounded">-</button>
+                    <button class="inc-btn px-2 bg-gray-200 rounded">+</button>
                 </div>
-                <button class="add-btn mt-2 px-3 py-1 bg-blue-600 text-white rounded">Add to Cart</button>
+                <button class="add-btn w-full px-3 py-1 bg-blue-600 text-white rounded" data-qty="0">Add</button>
             </div>
-            <div class="product-card bg-white rounded-lg shadow p-4 flex flex-col items-center">
-                <img class="w-full h-32 object-cover mb-2" src="https://via.placeholder.com/150" alt="Product 9">
-                <h3 class="font-semibold">Product 9</h3>
-                <div class="flex items-center mt-2 space-x-2">
-                    <button class="dec-btn px-2 bg-gray-300 rounded">-</button>
-                    <span class="qty">0</span>
-                    <button class="inc-btn px-2 bg-gray-300 rounded">+</button>
+            <div class="product-card bg-white rounded-lg shadow p-4 flex flex-col items-center text-center" data-name="Product 9">
+                <img class="w-24 h-24 object-cover mb-2 rounded" src="https://via.placeholder.com/150" alt="Product 9">
+                <h3 class="font-semibold mb-2">Product 9</h3>
+                <div class="flex items-center space-x-2 mb-2">
+                    <button class="dec-btn px-2 bg-gray-200 rounded">-</button>
+                    <button class="inc-btn px-2 bg-gray-200 rounded">+</button>
                 </div>
-                <button class="add-btn mt-2 px-3 py-1 bg-blue-600 text-white rounded">Add to Cart</button>
+                <button class="add-btn w-full px-3 py-1 bg-blue-600 text-white rounded" data-qty="0">Add</button>
             </div>
-            <div class="product-card bg-white rounded-lg shadow p-4 flex flex-col items-center">
-                <img class="w-full h-32 object-cover mb-2" src="https://via.placeholder.com/150" alt="Product 10">
-                <h3 class="font-semibold">Product 10</h3>
-                <div class="flex items-center mt-2 space-x-2">
-                    <button class="dec-btn px-2 bg-gray-300 rounded">-</button>
-                    <span class="qty">0</span>
-                    <button class="inc-btn px-2 bg-gray-300 rounded">+</button>
+            <div class="product-card bg-white rounded-lg shadow p-4 flex flex-col items-center text-center" data-name="Product 10">
+                <img class="w-24 h-24 object-cover mb-2 rounded" src="https://via.placeholder.com/150" alt="Product 10">
+                <h3 class="font-semibold mb-2">Product 10</h3>
+                <div class="flex items-center space-x-2 mb-2">
+                    <button class="dec-btn px-2 bg-gray-200 rounded">-</button>
+                    <button class="inc-btn px-2 bg-gray-200 rounded">+</button>
                 </div>
-                <button class="add-btn mt-2 px-3 py-1 bg-blue-600 text-white rounded">Add to Cart</button>
+                <button class="add-btn w-full px-3 py-1 bg-blue-600 text-white rounded" data-qty="0">Add</button>
             </div>
         </div>
     </main>
@@ -136,15 +141,27 @@
     </footer>
     <script>
         const cartCountEl = document.getElementById('cart-count');
-        let cartCount = 0;
+        let cart = JSON.parse(localStorage.getItem('cart') || '{}');
+
+        function updateCartCount() {
+            const total = Object.values(cart).reduce((a, b) => a + b, 0);
+            cartCountEl.textContent = total;
+        }
 
         function updateQty(card, delta) {
-            const qtyEl = card.querySelector('.qty');
-            let qty = parseInt(qtyEl.textContent);
+            const btn = card.querySelector('.add-btn');
+            const name = card.dataset.name;
+            let qty = parseInt(btn.dataset.qty);
             const newQty = Math.max(0, qty + delta);
-            cartCount += newQty - qty;
-            qtyEl.textContent = newQty;
-            cartCountEl.textContent = cartCount;
+            btn.dataset.qty = newQty;
+            btn.textContent = newQty > 0 ? newQty : 'Add';
+            if (newQty > 0) {
+                cart[name] = newQty;
+            } else {
+                delete cart[name];
+            }
+            localStorage.setItem('cart', JSON.stringify(cart));
+            updateCartCount();
         }
 
         document.querySelectorAll('.add-btn').forEach(btn => {
@@ -161,6 +178,24 @@
             btn.addEventListener('click', () => {
                 updateQty(btn.closest('.product-card'), -1);
             });
+        });
+
+        updateCartCount();
+
+        document.getElementById('menu-btn').addEventListener('click', () => {
+            document.getElementById('sidebar').classList.remove('-translate-x-full');
+            document.getElementById('overlay').classList.remove('hidden');
+        });
+        document.getElementById('close-sidebar').addEventListener('click', () => {
+            document.getElementById('sidebar').classList.add('-translate-x-full');
+            document.getElementById('overlay').classList.add('hidden');
+        });
+        document.getElementById('overlay').addEventListener('click', () => {
+            document.getElementById('sidebar').classList.add('-translate-x-full');
+            document.getElementById('overlay').classList.add('hidden');
+        });
+        document.getElementById('sidebar-logout').addEventListener('click', () => {
+            document.getElementById('logout-btn').click();
         });
 
         document.getElementById('logout-btn').addEventListener('click', () => {

--- a/profile.html
+++ b/profile.html
@@ -10,16 +10,30 @@
 <body>
     <nav class="bg-gradient-to-r from-blue-600 via-purple-600 to-pink-600 p-4 shadow-lg">
         <div class="container mx-auto flex justify-between items-center text-white">
-            <ul class="flex space-x-4">
+            <div class="flex items-center">
+                <span class="text-xl font-bold">Neebys</span>
+                <button id="menu-btn" class="sm:hidden ml-4 px-2 py-1 bg-white text-gray-800 rounded">☰</button>
+            </div>
+            <ul id="nav-links" class="hidden sm:flex space-x-4">
                 <li><a class="hover:underline" href="index.html">Home</a></li>
                 <li><a class="hover:underline" href="about.html">About</a></li>
                 <li><a class="hover:underline" href="contact.html">Contact</a></li>
             </ul>
-            <div class="space-x-2">
-                <span class="px-3 py-1 bg-white text-gray-800 rounded shadow">Profile</span>
+            <div class="space-x-2 flex items-center">
+                <span class="hidden sm:inline px-3 py-1 bg-white text-gray-800 rounded shadow">Profile</span>
             </div>
         </div>
     </nav>
+    <div id="sidebar" class="fixed inset-y-0 left-0 w-64 bg-white transform -translate-x-full transition-transform duration-200 sm:hidden z-50 shadow-lg">
+        <button id="close-sidebar" class="m-4 text-gray-600">Close</button>
+        <ul class="mt-8 space-y-4 px-4">
+            <li><a class="block hover:underline" href="index.html">Home</a></li>
+            <li><a class="block hover:underline" href="about.html">About</a></li>
+            <li><a class="block hover:underline" href="contact.html">Contact</a></li>
+            <li><span class="block">Profile</span></li>
+        </ul>
+    </div>
+    <div id="overlay" class="fixed inset-0 bg-black bg-opacity-50 hidden sm:hidden z-40"></div>
     <main class="container mx-auto py-10">
         <h1 class="text-3xl font-bold mb-4 text-center">User Profile</h1>
         <p class="text-center text-gray-700">This is a simple profile page.</p>
@@ -27,5 +41,19 @@
     <footer class="bg-gray-800 text-white text-center py-4 fixed bottom-0 w-full">
         <p>&copy; 2025 Basic Website</p>
     </footer>
+    <script>
+        document.getElementById('menu-btn').addEventListener('click', () => {
+            document.getElementById('sidebar').classList.remove('-translate-x-full');
+            document.getElementById('overlay').classList.remove('hidden');
+        });
+        document.getElementById('close-sidebar').addEventListener('click', () => {
+            document.getElementById('sidebar').classList.add('-translate-x-full');
+            document.getElementById('overlay').classList.add('hidden');
+        });
+        document.getElementById('overlay').addEventListener('click', () => {
+            document.getElementById('sidebar').classList.add('-translate-x-full');
+            document.getElementById('overlay').classList.add('hidden');
+        });
+    </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add brand-only navbar with sidebar menu for small screens
- style product cards and show quantity on the add button
- persist cart selections in localStorage and display them on new **cart.html**
- update profile page to use new responsive navbar

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_686cc8eccacc832a89cf197953501dd0