### PR TITLE
Improve logout flow and add signup page

### DIFF
--- a/cart.html
+++ b/cart.html
@@ -41,6 +41,14 @@
         </ul>
     </div>
     <div id="overlay" class="fixed inset-0 bg-black bg-opacity-50 hidden sm:hidden z-40"></div>
+    <!-- Logout modal -->
+    <div id="logout-modal" class="fixed inset-0 bg-black bg-opacity-50 hidden items-center justify-center z-50">
+        <div class="bg-white p-6 rounded shadow text-center">
+            <p class="mb-4">Do you want to logout?</p>
+            <button id="logout-confirm" class="bg-red-600 text-white px-4 py-2 rounded mr-2">Yes</button>
+            <button id="logout-cancel" class="bg-gray-300 px-4 py-2 rounded">No</button>
+        </div>
+    </div>
     <main class="container mx-auto py-8">
         <h1 class="text-2xl font-bold mb-4">Your Cart</h1>
         <div id="cart-items" class="space-y-4"></div>
@@ -98,10 +106,21 @@
             document.getElementById('logout-btn').click();
         });
 
+        const logoutModal = document.getElementById('logout-modal');
+        const logoutConfirm = document.getElementById('logout-confirm');
+        const logoutCancel = document.getElementById('logout-cancel');
+
         document.getElementById('logout-btn').addEventListener('click', () => {
-            if (confirm('Are you sure you want to logout?')) {
-                alert('Logged out');
-            }
+            logoutModal.classList.remove('hidden');
+            logoutModal.classList.add('flex');
+        });
+        logoutCancel.addEventListener('click', () => {
+            logoutModal.classList.add('hidden');
+            logoutModal.classList.remove('flex');
+        });
+        logoutConfirm.addEventListener('click', () => {
+            localStorage.removeItem('user');
+            window.location.href = 'signup.html';
         });
 
         updateCartCount();

--- a/index.html
+++ b/index.html
@@ -47,6 +47,14 @@
         </ul>
     </div>
     <div id="overlay" class="fixed inset-0 bg-black bg-opacity-50 hidden sm:hidden z-40"></div>
+    <!-- Logout modal -->
+    <div id="logout-modal" class="fixed inset-0 bg-black bg-opacity-50 hidden items-center justify-center z-50">
+        <div class="bg-white p-6 rounded shadow text-center">
+            <p class="mb-4">Do you want to logout?</p>
+            <button id="logout-confirm" class="bg-red-600 text-white px-4 py-2 rounded mr-2">Yes</button>
+            <button id="logout-cancel" class="bg-gray-300 px-4 py-2 rounded">No</button>
+        </div>
+    </div>
     <main class="container mx-auto py-8">
         <div class="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 gap-4" id="products">
 
@@ -191,10 +199,21 @@
             document.getElementById('logout-btn').click();
         });
 
+        const logoutModal = document.getElementById('logout-modal');
+        const logoutConfirm = document.getElementById('logout-confirm');
+        const logoutCancel = document.getElementById('logout-cancel');
+
         document.getElementById('logout-btn').addEventListener('click', () => {
-            if (confirm('Are you sure you want to logout?')) {
-                alert('Logged out');
-            }
+            logoutModal.classList.remove('hidden');
+            logoutModal.classList.add('flex');
+        });
+        logoutCancel.addEventListener('click', () => {
+            logoutModal.classList.add('hidden');
+            logoutModal.classList.remove('flex');
+        });
+        logoutConfirm.addEventListener('click', () => {
+            localStorage.removeItem('user');
+            window.location.href = 'signup.html';
         });
 
         const favicon = document.getElementById('favicon');

--- a/signup.html
+++ b/signup.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Sign Up</title>
+    <link rel="stylesheet" href="style.css">
+    <script src="https://cdn.tailwindcss.com"></script>
+</head>
+<body class="bg-gray-100 flex items-center justify-center min-h-screen fade-in">
+    <form id="signup-form" class="bg-white p-6 rounded shadow w-80">
+        <h1 class="text-xl font-bold mb-4 text-center">Create Account</h1>
+        <input id="username" type="text" placeholder="Username" required class="w-full border p-2 mb-4 rounded">
+        <input id="password" type="password" placeholder="Password" required class="w-full border p-2 mb-4 rounded">
+        <button type="submit" class="w-full bg-blue-600 text-white px-4 py-2 rounded">Sign Up</button>
+    </form>
+    <script>
+        document.getElementById('signup-form').addEventListener('submit', e => {
+            e.preventDefault();
+            const user = document.getElementById('username').value;
+            const pass = document.getElementById('password').value;
+            localStorage.setItem('user', JSON.stringify({user, pass}));
+            window.location.href = 'index.html';
+        });
+    </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add a signup page for basic localStorage auth
- replace confirm dialog with logout modal on index and cart pages
- redirect to signup on logout

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_686cedc9408c832aabe796f564e9152b